### PR TITLE
feature: links to google reviews

### DIFF
--- a/businesses.js
+++ b/businesses.js
@@ -16,11 +16,13 @@ var businesses = Object.freeze({
       id: 3,
       product: 'Central Hotel Yangon',
       industry: 'Entertainment/Tourism',
+      googleReviewUrl: 'https://www.google.com/travel/hotels/entity/CgsIuvWX--P-p8DuARAB/reviews'
     },
     {
       id: 4,
       product: 'Nan Myaing Café (Pwin Oo Lwin)',
       industry: 'Entertainment/Tourism',
+      googleReviewUrl: 'https://www.google.com/search?q=Nan%2BMyaing%2BCaf%C3%A9&oq=Nan%2BMyaing%2BCaf%C3%A9#lrd=0x30cc9e805d975e9f:0x5f69c1bcb1f4394d,1,,,'
     },
     {
       id: 31,

--- a/index.html
+++ b/index.html
@@ -54,6 +54,18 @@
           <header>
             <p class="card-header-title subtitle is-6">{{ item.product }}</p>
           </header>
+          <div
+            class="card-content px-4 pb-4 pt-1"
+            v-if="item.googleReviewUrl">
+              <a
+                v-if="item.googleReviewUrl"
+                :href="item.googleReviewUrl"
+                class="has-text-weight-semibold"
+                rel="noopener noreferrer nofollow"
+                target="_blank">
+                Google Reviews
+              </a>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Randomly saw this repo on my Github feed, hope you are all staying safe! 

This adds Google review URLs in JSON and a pattern for adding content to the Bulma cards, plus `googleReviewUrl`s for Nan Myaing Café and Central Hotel Yangon

**JSON with googleReviewUrl**

```javascript
    {
      id: 3,
      product: 'Central Hotel Yangon',
      industry: 'Entertainment/Tourism',
      googleReviewUrl: 'https://www.google.com/travel/hotels/entity/CgsIuvWX--P-p8DuARAB/reviews'
    },
```

**Card Content**

Can't edit padding/margin on the `<a>` in the Bulma card, so had to add the extra parent div with `card-content` class. 

There is a duplicate `v-if="item.googleReviewUrl"` on both the `<div>` and the `<a>` for convenience, e.g. if someone wants to add more items to the `card-content` div (`v-if="item.googleReviewUrl || item.___ || ...:`).  

```javascript
    <div
      class="card-content px-4 pb-4 pt-1"
      v-if="item.googleReviewUrl">
        <a
          v-if="item.googleReviewUrl"
          :href="item.googleReviewUrl"
          class="has-text-weight-semibold"
          rel="noopener noreferrer nofollow"
          target="_blank">
          Google Reviews
        </a>
    </div>
```